### PR TITLE
chore: future-proof tap workflow and harden cask generation

### DIFF
--- a/.github/workflows/update-cask.yml
+++ b/.github/workflows/update-cask.yml
@@ -5,9 +5,16 @@ on:
     - cron: '0 */6 * * *' # runs every 6 hours
   workflow_dispatch:
 
+# Prevent a manual dispatch from overlapping a scheduled run.
+concurrency:
+  group: update-casks
+  cancel-in-progress: false
+
 jobs:
   update-casks:
-    runs-on: macos-latest
+    # Pure-Ruby job (GitHub API + asset download + file writes); nothing here
+    # needs macOS, so we use the faster, cheaper, lower-churn Ubuntu runner.
+    runs-on: ubuntu-latest
 
     permissions:
       contents: write
@@ -18,7 +25,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0 # ensure full history for versioning
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
 
       - name: Run update_casks.rb
         env:

--- a/Casks/godot-dev.rb
+++ b/Casks/godot-dev.rb
@@ -11,14 +11,14 @@ cask "godot-dev" do
   livecheck do
     url "https://github.com/godotengine/godot-builds/releases"
     strategy :github_latest
-    regex(/^(\d+\.\d+(?:\.\d+)?-(?:dev|beta|rc)\d+)$/)
+    regex(/^(\d+\.\d+(?:\.\d+)?-[a-z]+\d*)$/)
   end
 
   auto_updates true
   conflicts_with cask: "godot-dev@*"
+  depends_on :macos
 
   app "Godot.app", target: "Godot Dev.app"
-
   binary "#{appdir}/Godot Dev.app/Contents/MacOS/Godot", target: "godot-dev"
 
   zap trash: [

--- a/Casks/godot-dev@4.6-dev5.rb
+++ b/Casks/godot-dev@4.6-dev5.rb
@@ -5,20 +5,18 @@ cask "godot-dev@4.6-dev5" do
   url "https://github.com/godotengine/godot-builds/releases/download/4.6-dev5/Godot_v4.6-dev5_macos.universal.zip",
       verified: "github.com/godotengine/godot-builds/"
   name "Godot Engine (Build 4.6-dev5)"
-  desc "Free and open source 2D and 3D game engine (godot-builds release4.6-dev5)"
+  desc "Free and open source 2D and 3D game engine (godot-builds release 4.6-dev5)"
   homepage "https://godotengine.org/"
 
   livecheck do
     skip "This is a versioned cask"
-    
-    
   end
 
   auto_updates true
   conflicts_with cask: "godot-dev"
+  depends_on :macos
 
   app "Godot.app", target: "Godot Dev.app"
-
   binary "#{appdir}/Godot Dev.app/Contents/MacOS/Godot", target: "godot-dev"
 
   zap trash: [

--- a/Casks/godot-dev@4.6-dev6.rb
+++ b/Casks/godot-dev@4.6-dev6.rb
@@ -5,20 +5,18 @@ cask "godot-dev@4.6-dev6" do
   url "https://github.com/godotengine/godot-builds/releases/download/4.6-dev6/Godot_v4.6-dev6_macos.universal.zip",
       verified: "github.com/godotengine/godot-builds/"
   name "Godot Engine (Build 4.6-dev6)"
-  desc "Free and open source 2D and 3D game engine (godot-builds release4.6-dev6)"
+  desc "Free and open source 2D and 3D game engine (godot-builds release 4.6-dev6)"
   homepage "https://godotengine.org/"
 
   livecheck do
     skip "This is a versioned cask"
-    
-    
   end
 
   auto_updates true
   conflicts_with cask: "godot-dev"
+  depends_on :macos
 
   app "Godot.app", target: "Godot Dev.app"
-
   binary "#{appdir}/Godot Dev.app/Contents/MacOS/Godot", target: "godot-dev"
 
   zap trash: [

--- a/Casks/godot-dev@4.6-rc1.rb
+++ b/Casks/godot-dev@4.6-rc1.rb
@@ -5,20 +5,18 @@ cask "godot-dev@4.6-rc1" do
   url "https://github.com/godotengine/godot-builds/releases/download/4.6-rc1/Godot_v4.6-rc1_macos.universal.zip",
       verified: "github.com/godotengine/godot-builds/"
   name "Godot Engine (Build 4.6-rc1)"
-  desc "Free and open source 2D and 3D game engine (godot-builds release4.6-rc1)"
+  desc "Free and open source 2D and 3D game engine (godot-builds release 4.6-rc1)"
   homepage "https://godotengine.org/"
 
   livecheck do
     skip "This is a versioned cask"
-    
-    
   end
 
   auto_updates true
   conflicts_with cask: "godot-dev"
+  depends_on :macos
 
   app "Godot.app", target: "Godot Dev.app"
-
   binary "#{appdir}/Godot Dev.app/Contents/MacOS/Godot", target: "godot-dev"
 
   zap trash: [

--- a/Casks/godot-dev@4.6-rc2.rb
+++ b/Casks/godot-dev@4.6-rc2.rb
@@ -5,20 +5,18 @@ cask "godot-dev@4.6-rc2" do
   url "https://github.com/godotengine/godot-builds/releases/download/4.6-rc2/Godot_v4.6-rc2_macos.universal.zip",
       verified: "github.com/godotengine/godot-builds/"
   name "Godot Engine (Build 4.6-rc2)"
-  desc "Free and open source 2D and 3D game engine (godot-builds release4.6-rc2)"
+  desc "Free and open source 2D and 3D game engine (godot-builds release 4.6-rc2)"
   homepage "https://godotengine.org/"
 
   livecheck do
     skip "This is a versioned cask"
-    
-    
   end
 
   auto_updates true
   conflicts_with cask: "godot-dev"
+  depends_on :macos
 
   app "Godot.app", target: "Godot Dev.app"
-
   binary "#{appdir}/Godot Dev.app/Contents/MacOS/Godot", target: "godot-dev"
 
   zap trash: [

--- a/Casks/godot-dev@4.6.3-rc2.rb
+++ b/Casks/godot-dev@4.6.3-rc2.rb
@@ -5,20 +5,18 @@ cask "godot-dev@4.6.3-rc2" do
   url "https://github.com/godotengine/godot-builds/releases/download/4.6.3-rc2/Godot_v4.6.3-rc2_macos.universal.zip",
       verified: "github.com/godotengine/godot-builds/"
   name "Godot Engine (Build 4.6.3-rc2)"
-  desc "Free and open source 2D and 3D game engine (godot-builds release4.6.3-rc2)"
+  desc "Free and open source 2D and 3D game engine (godot-builds release 4.6.3-rc2)"
   homepage "https://godotengine.org/"
 
   livecheck do
     skip "This is a versioned cask"
-    
-    
   end
 
   auto_updates true
   conflicts_with cask: "godot-dev"
+  depends_on :macos
 
   app "Godot.app", target: "Godot Dev.app"
-
   binary "#{appdir}/Godot Dev.app/Contents/MacOS/Godot", target: "godot-dev"
 
   zap trash: [

--- a/Casks/godot-dev@4.7-beta2.rb
+++ b/Casks/godot-dev@4.7-beta2.rb
@@ -5,20 +5,18 @@ cask "godot-dev@4.7-beta2" do
   url "https://github.com/godotengine/godot-builds/releases/download/4.7-beta2/Godot_v4.7-beta2_macos.universal.zip",
       verified: "github.com/godotengine/godot-builds/"
   name "Godot Engine (Build 4.7-beta2)"
-  desc "Free and open source 2D and 3D game engine (godot-builds release4.7-beta2)"
+  desc "Free and open source 2D and 3D game engine (godot-builds release 4.7-beta2)"
   homepage "https://godotengine.org/"
 
   livecheck do
     skip "This is a versioned cask"
-    
-    
   end
 
   auto_updates true
   conflicts_with cask: "godot-dev"
+  depends_on :macos
 
   app "Godot.app", target: "Godot Dev.app"
-
   binary "#{appdir}/Godot Dev.app/Contents/MacOS/Godot", target: "godot-dev"
 
   zap trash: [

--- a/Casks/godot-dev@4.7-beta3.rb
+++ b/Casks/godot-dev@4.7-beta3.rb
@@ -5,20 +5,18 @@ cask "godot-dev@4.7-beta3" do
   url "https://github.com/godotengine/godot-builds/releases/download/4.7-beta3/Godot_v4.7-beta3_macos.universal.zip",
       verified: "github.com/godotengine/godot-builds/"
   name "Godot Engine (Build 4.7-beta3)"
-  desc "Free and open source 2D and 3D game engine (godot-builds release4.7-beta3)"
+  desc "Free and open source 2D and 3D game engine (godot-builds release 4.7-beta3)"
   homepage "https://godotengine.org/"
 
   livecheck do
     skip "This is a versioned cask"
-    
-    
   end
 
   auto_updates true
   conflicts_with cask: "godot-dev"
+  depends_on :macos
 
   app "Godot.app", target: "Godot Dev.app"
-
   binary "#{appdir}/Godot Dev.app/Contents/MacOS/Godot", target: "godot-dev"
 
   zap trash: [

--- a/Casks/godot-dev@4.7-beta4.rb
+++ b/Casks/godot-dev@4.7-beta4.rb
@@ -5,20 +5,18 @@ cask "godot-dev@4.7-beta4" do
   url "https://github.com/godotengine/godot-builds/releases/download/4.7-beta4/Godot_v4.7-beta4_macos.universal.zip",
       verified: "github.com/godotengine/godot-builds/"
   name "Godot Engine (Build 4.7-beta4)"
-  desc "Free and open source 2D and 3D game engine (godot-builds release4.7-beta4)"
+  desc "Free and open source 2D and 3D game engine (godot-builds release 4.7-beta4)"
   homepage "https://godotengine.org/"
 
   livecheck do
     skip "This is a versioned cask"
-    
-    
   end
 
   auto_updates true
   conflicts_with cask: "godot-dev"
+  depends_on :macos
 
   app "Godot.app", target: "Godot Dev.app"
-
   binary "#{appdir}/Godot Dev.app/Contents/MacOS/Godot", target: "godot-dev"
 
   zap trash: [

--- a/Casks/godot-dev@4.7-beta5.rb
+++ b/Casks/godot-dev@4.7-beta5.rb
@@ -5,20 +5,18 @@ cask "godot-dev@4.7-beta5" do
   url "https://github.com/godotengine/godot-builds/releases/download/4.7-beta5/Godot_v4.7-beta5_macos.universal.zip",
       verified: "github.com/godotengine/godot-builds/"
   name "Godot Engine (Build 4.7-beta5)"
-  desc "Free and open source 2D and 3D game engine (godot-builds release4.7-beta5)"
+  desc "Free and open source 2D and 3D game engine (godot-builds release 4.7-beta5)"
   homepage "https://godotengine.org/"
 
   livecheck do
     skip "This is a versioned cask"
-    
-    
   end
 
   auto_updates true
   conflicts_with cask: "godot-dev"
+  depends_on :macos
 
   app "Godot.app", target: "Godot Dev.app"
-
   binary "#{appdir}/Godot Dev.app/Contents/MacOS/Godot", target: "godot-dev"
 
   zap trash: [

--- a/Casks/godot-dev@4.7-dev1.rb
+++ b/Casks/godot-dev@4.7-dev1.rb
@@ -5,20 +5,18 @@ cask "godot-dev@4.7-dev1" do
   url "https://github.com/godotengine/godot-builds/releases/download/4.7-dev1/Godot_v4.7-dev1_macos.universal.zip",
       verified: "github.com/godotengine/godot-builds/"
   name "Godot Engine (Build 4.7-dev1)"
-  desc "Free and open source 2D and 3D game engine (godot-builds release4.7-dev1)"
+  desc "Free and open source 2D and 3D game engine (godot-builds release 4.7-dev1)"
   homepage "https://godotengine.org/"
 
   livecheck do
     skip "This is a versioned cask"
-    
-    
   end
 
   auto_updates true
   conflicts_with cask: "godot-dev"
+  depends_on :macos
 
   app "Godot.app", target: "Godot Dev.app"
-
   binary "#{appdir}/Godot Dev.app/Contents/MacOS/Godot", target: "godot-dev"
 
   zap trash: [

--- a/Casks/godot-dev@4.7-dev2.rb
+++ b/Casks/godot-dev@4.7-dev2.rb
@@ -5,20 +5,18 @@ cask "godot-dev@4.7-dev2" do
   url "https://github.com/godotengine/godot-builds/releases/download/4.7-dev2/Godot_v4.7-dev2_macos.universal.zip",
       verified: "github.com/godotengine/godot-builds/"
   name "Godot Engine (Build 4.7-dev2)"
-  desc "Free and open source 2D and 3D game engine (godot-builds release4.7-dev2)"
+  desc "Free and open source 2D and 3D game engine (godot-builds release 4.7-dev2)"
   homepage "https://godotengine.org/"
 
   livecheck do
     skip "This is a versioned cask"
-    
-    
   end
 
   auto_updates true
   conflicts_with cask: "godot-dev"
+  depends_on :macos
 
   app "Godot.app", target: "Godot Dev.app"
-
   binary "#{appdir}/Godot Dev.app/Contents/MacOS/Godot", target: "godot-dev"
 
   zap trash: [

--- a/Casks/godot-dev@4.7-dev3.rb
+++ b/Casks/godot-dev@4.7-dev3.rb
@@ -5,20 +5,18 @@ cask "godot-dev@4.7-dev3" do
   url "https://github.com/godotengine/godot-builds/releases/download/4.7-dev3/Godot_v4.7-dev3_macos.universal.zip",
       verified: "github.com/godotengine/godot-builds/"
   name "Godot Engine (Build 4.7-dev3)"
-  desc "Free and open source 2D and 3D game engine (godot-builds release4.7-dev3)"
+  desc "Free and open source 2D and 3D game engine (godot-builds release 4.7-dev3)"
   homepage "https://godotengine.org/"
 
   livecheck do
     skip "This is a versioned cask"
-    
-    
   end
 
   auto_updates true
   conflicts_with cask: "godot-dev"
+  depends_on :macos
 
   app "Godot.app", target: "Godot Dev.app"
-
   binary "#{appdir}/Godot Dev.app/Contents/MacOS/Godot", target: "godot-dev"
 
   zap trash: [

--- a/Casks/godot-dev@4.7-dev4.rb
+++ b/Casks/godot-dev@4.7-dev4.rb
@@ -5,20 +5,18 @@ cask "godot-dev@4.7-dev4" do
   url "https://github.com/godotengine/godot-builds/releases/download/4.7-dev4/Godot_v4.7-dev4_macos.universal.zip",
       verified: "github.com/godotengine/godot-builds/"
   name "Godot Engine (Build 4.7-dev4)"
-  desc "Free and open source 2D and 3D game engine (godot-builds release4.7-dev4)"
+  desc "Free and open source 2D and 3D game engine (godot-builds release 4.7-dev4)"
   homepage "https://godotengine.org/"
 
   livecheck do
     skip "This is a versioned cask"
-    
-    
   end
 
   auto_updates true
   conflicts_with cask: "godot-dev"
+  depends_on :macos
 
   app "Godot.app", target: "Godot Dev.app"
-
   binary "#{appdir}/Godot Dev.app/Contents/MacOS/Godot", target: "godot-dev"
 
   zap trash: [

--- a/Casks/godot-dev@4.7-dev5.rb
+++ b/Casks/godot-dev@4.7-dev5.rb
@@ -5,20 +5,18 @@ cask "godot-dev@4.7-dev5" do
   url "https://github.com/godotengine/godot-builds/releases/download/4.7-dev5/Godot_v4.7-dev5_macos.universal.zip",
       verified: "github.com/godotengine/godot-builds/"
   name "Godot Engine (Build 4.7-dev5)"
-  desc "Free and open source 2D and 3D game engine (godot-builds release4.7-dev5)"
+  desc "Free and open source 2D and 3D game engine (godot-builds release 4.7-dev5)"
   homepage "https://godotengine.org/"
 
   livecheck do
     skip "This is a versioned cask"
-    
-    
   end
 
   auto_updates true
   conflicts_with cask: "godot-dev"
+  depends_on :macos
 
   app "Godot.app", target: "Godot Dev.app"
-
   binary "#{appdir}/Godot Dev.app/Contents/MacOS/Godot", target: "godot-dev"
 
   zap trash: [

--- a/Casks/godot-dev@4.7-rc1.rb
+++ b/Casks/godot-dev@4.7-rc1.rb
@@ -5,20 +5,18 @@ cask "godot-dev@4.7-rc1" do
   url "https://github.com/godotengine/godot-builds/releases/download/4.7-rc1/Godot_v4.7-rc1_macos.universal.zip",
       verified: "github.com/godotengine/godot-builds/"
   name "Godot Engine (Build 4.7-rc1)"
-  desc "Free and open source 2D and 3D game engine (godot-builds release4.7-rc1)"
+  desc "Free and open source 2D and 3D game engine (godot-builds release 4.7-rc1)"
   homepage "https://godotengine.org/"
 
   livecheck do
     skip "This is a versioned cask"
-    
-    
   end
 
   auto_updates true
   conflicts_with cask: "godot-dev"
+  depends_on :macos
 
   app "Godot.app", target: "Godot Dev.app"
-
   binary "#{appdir}/Godot Dev.app/Contents/MacOS/Godot", target: "godot-dev"
 
   zap trash: [

--- a/Casks/godot-dev@4.7-rc2.rb
+++ b/Casks/godot-dev@4.7-rc2.rb
@@ -5,20 +5,18 @@ cask "godot-dev@4.7-rc2" do
   url "https://github.com/godotengine/godot-builds/releases/download/4.7-rc2/Godot_v4.7-rc2_macos.universal.zip",
       verified: "github.com/godotengine/godot-builds/"
   name "Godot Engine (Build 4.7-rc2)"
-  desc "Free and open source 2D and 3D game engine (godot-builds release4.7-rc2)"
+  desc "Free and open source 2D and 3D game engine (godot-builds release 4.7-rc2)"
   homepage "https://godotengine.org/"
 
   livecheck do
     skip "This is a versioned cask"
-    
-    
   end
 
   auto_updates true
   conflicts_with cask: "godot-dev"
+  depends_on :macos
 
   app "Godot.app", target: "Godot Dev.app"
-
   binary "#{appdir}/Godot Dev.app/Contents/MacOS/Godot", target: "godot-dev"
 
   zap trash: [

--- a/update_casks.rb
+++ b/update_casks.rb
@@ -93,7 +93,7 @@ def compute_sha256(asset_url)
   begin
     uri = URI(asset_url)
     puts "Downloading asset to compute sha256: #{asset_url}"
-    asset_data = URI.open(uri, ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE).read
+    asset_data = URI.open(uri).read
     sha256 = Digest::SHA256.hexdigest(asset_data)
     puts "Computed sha256: #{sha256}"
     sha256
@@ -121,6 +121,20 @@ def generate_cask_content(version, sha256_checksum, latest = false)
   cask_name = latest ? "godot-dev" : "godot-dev@#{version}"
   app_target = "Godot Dev.app"
 
+  # The livecheck regex deliberately mirrors PRERELEASE_TAG's philosophy: the
+  # stage label is matched as [a-z]+ rather than a hardcoded (dev|beta|rc) list,
+  # so a new Godot stage (e.g. alpha) is picked up automatically without edits.
+  livecheck_body =
+    if latest
+      [
+        '    url "https://github.com/godotengine/godot-builds/releases"',
+        '    strategy :github_latest',
+        '    regex(/^(\d+\.\d+(?:\.\d+)?-[a-z]+\d*)$/)',
+      ].join("\n")
+    else
+      '    skip "This is a versioned cask"'
+    end
+
   <<~RUBY
     cask "#{cask_name}" do
       version "#{version}"
@@ -129,20 +143,18 @@ def generate_cask_content(version, sha256_checksum, latest = false)
       url "https://github.com/godotengine/godot-builds/releases/download/#{version}/Godot_v#{version}_macos.universal.zip",
           verified: "github.com/godotengine/godot-builds/"
       name "Godot Engine #{latest ? '(Latest)' : "(Build #{version})"}"
-      desc "Free and open source 2D and 3D game engine #{latest ? '(Latest godot-builds release)' : "(godot-builds release#{version})"}"
+      desc "Free and open source 2D and 3D game engine #{latest ? '(Latest godot-builds release)' : "(godot-builds release #{version})"}"
       homepage "https://godotengine.org/"
 
       livecheck do
-        #{latest ? 'url "https://github.com/godotengine/godot-builds/releases"' : 'skip "This is a versioned cask"'}
-        #{latest ? 'strategy :github_latest' : ''}
-        #{latest ? 'regex(/^(\d+\.\d+(?:\.\d+)?-(?:dev|beta|rc)\d+)$/)' : ''}
+    #{livecheck_body}
       end
 
       auto_updates true
       conflicts_with cask: #{latest ? '"godot-dev@*"' : '"godot-dev"'}
+      depends_on :macos
 
       app "Godot.app", target: "#{app_target}"
-
       binary "\#{appdir}/#{app_target}/Contents/MacOS/Godot", target: "godot-dev"
 
       zap trash: [
@@ -203,14 +215,19 @@ def update_casks(versions)
     end
   end
 
-  # Latest cask — reuse the SHA256 from the versioned cask if available
+  # Latest cask — reuse the SHA256 from the versioned cask if available.
+  # If we can't obtain a checksum for the *latest* release, hard-fail: a missing
+  # download almost always means Godot changed the macOS asset naming, and silently
+  # skipping would leave the main cask stale without surfacing the problem.
   latest_version = versions.first
   sha256_checksum = read_sha256_from_cask(latest_version) || fetch_sha256(latest_version)
-  if sha256_checksum
-    write_cask_file("godot-dev", generate_cask_content(latest_version, sha256_checksum, true))
-  else
-    puts "Skipping latest cask update due to missing sha256 checksum for #{latest_version}."
+  unless sha256_checksum
+    abort "ERROR: could not obtain sha256 for latest release #{latest_version}. " \
+          "The macOS asset URL may have changed (expected " \
+          "Godot_v#{latest_version}_macos.universal.zip) — update fetch_sha256."
   end
+
+  write_cask_file("godot-dev", generate_cask_content(latest_version, sha256_checksum, true))
 end
 
 def main
@@ -242,4 +259,4 @@ def main
   write_latest_release(versions.first)
 end
 
-main
+main if __FILE__ == $PROGRAM_NAME


### PR DESCRIPTION
- workflow: move from macos-latest to ubuntu-latest (pure-Ruby job needs no macOS), pin Ruby via ruby/setup-ruby@v1, add a concurrency guard
- script: hard-fail when the latest release's sha256 can't be fetched so an asset-naming change surfaces instead of silently going stale
- script: de-hardcode the livecheck regex ([a-z]+ instead of dev|beta|rc) to match PRERELEASE_TAG and auto-pick-up any new Godot stage
- script: fix desc spacing, drop SSL VERIFY_NONE, add depends_on :macos, and clean stanza grouping so all casks pass `brew style`
- guard main with __FILE__ == $PROGRAM_NAME for testability